### PR TITLE
Speedup through improved requests and db commits

### DIFF
--- a/wizdiff/db.py
+++ b/wizdiff/db.py
@@ -47,14 +47,14 @@ class WizDiffDatabase:
 
     def init_database(self):
         self._connection.executescript(TABLE_SCRIPT)
-        self._connection.commit()
+        self.commit()
 
     def add_revision_info(self, name: str, date: datetime = None):
         if date is None:
             date = datetime.utcnow()
 
         self._connection.execute("INSERT INTO RevisionInfo (revision_name, date_) VALUES (?, ?);", (name, date))
-        self._connection.commit()
+        self.commit()
 
     def get_latest_revision(self) -> Optional[str]:
         cur = self._connection.execute("SELECT revision_name FROM RevisionInfo ORDER BY date_ DESC;")
@@ -75,7 +75,6 @@ class WizDiffDatabase:
             "INSERT INTO VersionedFileInfo (crc, size_, revision, name) VALUES (?, ?, ?, ?);",
             (crc, size, revision, name),
         )
-        self._connection.commit()
 
     def check_if_versioned_file_updated(self, new_crc: int, new_size: int, old_revision: str, name: str):
         cur = self._connection.execute(
@@ -113,7 +112,6 @@ class WizDiffDatabase:
             "INSERT INTO WadFileInfo (crc, size_, revision, name, wad_name) VALUES (?, ?, ?, ?, ?);",
             (crc, size, revision, file_name, wad_name),
         )
-        self._connection.commit()
 
     # TODO: maybe merge this and check_if_versioned_file_updated together (past first line is duplicated)
     def check_if_wad_file_updated(self, new_crc: int, new_size: int, old_revision: str, file_name: str, wad_name: str):
@@ -133,3 +131,9 @@ class WizDiffDatabase:
 
         else:
             return FileUpdateType.unchanged, (old_crc, old_size)
+
+    def commit(self):
+        self._connection.commit()
+
+    def vacuum(self):
+        self._connection.execute("VACUUM;")

--- a/wizdiff/utils.py
+++ b/wizdiff/utils.py
@@ -1,35 +1,7 @@
-import struct
 import re
-import gzip
-from socket import create_connection
-
-import requests
 
 
 REVERSION_URL_REGEX = re.compile(r"WizPatcher/([^/]+)")
-JOURNAL_ENTRY = "<lll?ll"
-JOURNAL_ENTRY_SIZE = struct.calcsize(JOURNAL_ENTRY)
-
-
-def get_patch_urls():
-    with create_connection(("patch.us.wizard101.com", 12500)) as socket:
-        socket.send(b"\x0D\xF0\x24\x00\x00\x00\x00\x00\x08\x01\x20" + bytes(29))
-        socket.recv(4096)  # session offer or whatever
-        data = socket.recv(4096)
-
-    def _read_url(start: int):
-        str_len_data = data[start:start + 2]
-        str_len = struct.unpack("<H", str_len_data)[0]
-
-        str_data = data[start + 2: start + 2 + str_len]
-
-        return str_data.decode()
-
-    # -2 for the str len
-    file_list_url_start = data.find(b"http") - 2
-    base_url_start = data.rfind(b"http") - 2
-
-    return _read_url(file_list_url_start), _read_url(base_url_start)
 
 
 def get_revision_from_url(url: str):
@@ -39,56 +11,3 @@ def get_revision_from_url(url: str):
         raise ValueError(f"Reversion string not found in {url}")
 
     return res.group(1)
-
-
-def get_url_data(url: str, *, data_range: tuple[int, int] = None) -> bytes:
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"
-    }
-
-    if data_range:
-        headers["Range"] = f"bytes={data_range[0]}-{data_range[1]}"
-
-    with requests.get(url, headers=headers) as res:
-        res.raise_for_status()
-        return res.content
-
-
-def get_wad_journal_crcs(wad_url: str) -> dict:
-    # .hdr.gz = header gzipped
-    wad_header_data = get_url_data(wad_url + ".hdr.gz")
-
-    try:
-        wad_header_data = gzip.decompress(wad_header_data)
-    except gzip.BadGzipFile:
-        pass
-
-    signature, version, file_count = struct.unpack("<5sII", wad_header_data[:13])
-
-    if signature != b"KIWAD":
-        raise RuntimeError(f"Invalid signature {signature}")
-
-    data_offset = 13
-
-    if version >= 2:
-        data_offset += 1
-
-    res = {}
-
-    for _ in range(file_count):
-        journal_entry_data = wad_header_data[data_offset:data_offset + JOURNAL_ENTRY_SIZE]
-        offset, size, zsize, is_zip, crc, name_length = struct.unpack(JOURNAL_ENTRY, journal_entry_data)
-
-        name_data = wad_header_data[data_offset + JOURNAL_ENTRY_SIZE:data_offset + JOURNAL_ENTRY_SIZE + name_length]
-        name = name_data.decode()[:-1]
-        data_offset += JOURNAL_ENTRY_SIZE + name_length
-
-        res[name] = (crc, size)
-
-    return res
-
-
-if __name__ == "__main__":
-    print(get_wad_journal_crcs("http://versionec.us.wizard101.com/WizPatcher/"
-                               "V_r703991.Wizard_1_460/LatestBuild/Data/GameDa"
-                               "ta/Arcanum-Interiors-AR_Z01_AstralPlane_Repeat.wad"))

--- a/wizdiff/webdriver.py
+++ b/wizdiff/webdriver.py
@@ -1,0 +1,85 @@
+import struct
+import gzip
+from socket import create_connection
+from typing import *
+
+import requests
+
+JOURNAL_ENTRY = "<lll?ll"
+JOURNAL_ENTRY_SIZE = struct.calcsize(JOURNAL_ENTRY)
+
+class WebDriver:
+  def __init__(self):
+    self.session = requests.Session()
+
+  @staticmethod
+  def get_patch_urls() -> Tuple[str, str]:
+    with create_connection(("patch.us.wizard101.com", 12500)) as socket:
+        socket.send(b"\x0D\xF0\x24\x00\x00\x00\x00\x00\x08\x01\x20" + bytes(29))
+        socket.recv(4096)  # session offer or whatever
+        data = socket.recv(4096)
+
+    def _read_url(start: int):
+        str_len_data = data[start:start + 2]
+        str_len = struct.unpack("<H", str_len_data)[0]
+
+        str_data = data[start + 2: start + 2 + str_len]
+
+        return str_data.decode()
+
+    # -2 for the str len
+    file_list_url_start = data.find(b"http") - 2
+    base_url_start = data.rfind(b"http") - 2
+
+    return _read_url(file_list_url_start), _read_url(base_url_start)
+
+  def get_url_data(self, url: str, *, data_range: tuple[int, int] = None) -> bytes:
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"
+    }
+
+    if data_range:
+        headers["Range"] = f"bytes={data_range[0]}-{data_range[1]}"
+
+    with self.session.get(url, headers=headers) as res:
+        res.raise_for_status()
+        return res.content
+
+  def get_wad_journal_crcs(self, wad_url: str) -> dict:
+    # .hdr.gz = header gzipped
+    wad_header_data = self.get_url_data(wad_url + ".hdr.gz")
+
+    try:
+        wad_header_data = gzip.decompress(wad_header_data)
+    except gzip.BadGzipFile:
+        pass
+
+    signature, version, file_count = struct.unpack("<5sII", wad_header_data[:13])
+
+    if signature != b"KIWAD":
+        raise RuntimeError(f"Invalid signature {signature}")
+
+    data_offset = 13
+
+    if version >= 2:
+        data_offset += 1
+
+    res = {}
+
+    for _ in range(file_count):
+        journal_entry_data = wad_header_data[data_offset:data_offset + JOURNAL_ENTRY_SIZE]
+        offset, size, zsize, is_zip, crc, name_length = struct.unpack(JOURNAL_ENTRY, journal_entry_data)
+
+        name_data = wad_header_data[data_offset + JOURNAL_ENTRY_SIZE:data_offset + JOURNAL_ENTRY_SIZE + name_length]
+        name = name_data.decode()[:-1]
+        data_offset += JOURNAL_ENTRY_SIZE + name_length
+
+        res[name] = (crc, size)
+
+    return res
+
+if __name__ == "__main__":
+    driver = WebDriver()
+    print(driver.get_wad_journal_crcs("http://versionec.us.wizard101.com/WizPatcher/"
+                               "V_r703991.Wizard_1_460/LatestBuild/Data/GameDa"
+                               "ta/Arcanum-Interiors-AR_Z01_AstralPlane_Repeat.wad"))


### PR DESCRIPTION
Moved all web requests into their own class to keep the session alive. Moved db commits out of most db functions and calling a new db.commit() function manually when appropriate.
For further improvements in speed, consider logging wad files in the INFO category while keeping inner files in DEBUG. Then disable all DEBUG logs, as they will take about 500 seconds (maybe more) while the actual db init takes ~30 seconds.